### PR TITLE
Fix the scheduled build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -102,7 +102,7 @@ jobs:
       type: ${{ inputs.type }}
   build_matrix:
     needs: inferprojects
-    if: ( inputs.type == 'workflow_dispatch' || inputs.type == 'schedule' ) && needs.inferprojects.outputs.projects != '[]'
+    if: ( inputs.type == 'workflow_dispatch' || github.event_name == 'schedule' ) && needs.inferprojects.outputs.projects != '[]'
     name: Build ${{ matrix.project }}
     strategy:
       fail-fast: false


### PR DESCRIPTION
Use the event name instead of the undefined inputs type