### PR TITLE
Update census example to use datashader 0.14.5a1

### DIFF
--- a/census/anaconda-project.yml
+++ b/census/anaconda-project.yml
@@ -10,7 +10,8 @@ examples_config:
 
 user_fields: [examples_config]
 
-channels: 
+channels:
+- pyviz/label/dev  # Temporary until datashader 0.15.0 is on conda-forge/defaults
 - conda-forge
 - nodefaults
 
@@ -18,13 +19,11 @@ packages: &pkgs
 - python=3.10
 - notebook
 - colorcet
-- dask=2022.11.1
-- datashader
-- fastparquet
+- dask
+- datashader=0.14.5a1
 - holoviews
-- python-snappy
 - param
-- pandas<2
+- pandas
 
 dependencies: *pkgs
 

--- a/census/census.ipynb
+++ b/census/census.ipynb
@@ -43,8 +43,8 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "df = dd.read_parquet('./data/census2010.parq', engine='fastparquet')\n",
-    "df = df.categorize('race')  # Required for datashader<=0.14.4\n",
+    "df = dd.read_parquet('./data/census2010.parq')\n",
+    "df = df.categorize('race')  # Workaround for https://github.com/holoviz/datashader/issues/1202\n",
     "df = df.persist()"
    ]
   },
@@ -155,6 +155,15 @@
     "%%time\n",
     "cvs = ds.Canvas(plot_width, plot_height, *webm(*USA))\n",
     "agg = cvs.points(df, 'easting', 'northing')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "agg.dtype, agg.shape, agg.min().item(), agg.max().item()"
    ]
   },
   {
@@ -657,9 +666,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.11"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Work in progress to update the census example environment to use the latest `datashader`, `bokeh`, `panel`, etc. Initially using `datashader` dev release `0.14.5a` from `pyviz/label/dev` channel, and other packages from `conda-forge` rather than `defaults` until everything required is on `defaults`, which is well underway. The other change is to use `pyarrow` rather than `fastparquet`.

It results in the following packages used:

| Package | Before this PR | With this PR |
| --- | --- | --- |
| bokeh | 2.4.3 | 3.1.1 |
| dask | 2022.11.1 | 2023.5.0 |
| datashader | 0.14.4 | 0.14.5a1 |
| holoviews | 1.16.0 | 1.16.0 |
| pandas | 1.5.3 | 2.0.1 |
| panel | 0.14.4 | 1.0.3 |
| pyarrow | N/A | 12.0 |

It still includes the workaround for https://github.com/holoviz/datashader/issues/1202.

Tested locally on `osx-arm64`, historically one of the most problematic. It gives a bunch of `datashader` warnings, all of which are fixed and will be in the imminent `0.15.0` release. The output renders correctly for me except one plot is missing with a `tornado` error reported at the command-line, and the interactive plots at the end work correctly.

Given these results, I conclude that there is nothing fundamentally wrong with `datashader` to prevent going ahead with the `0.15.0` release. Once that is done here is a possible plan:

1. Update environment to use `datashader 0.15.0` to confirm that warnings have gone.
2. Ensure all `holoviz` packages are available on `defaults`.
3. Update environment to use `defaults` rather than `conda-forge` and `pyviz/label/dev`.
4. Investigate and/or deal with the `tornado` error if it still occurs.
5. Deal with https://github.com/holoviz/datashader/issues/1202.