### PR TITLE
infra: add comment on PRs to ask for dev site review

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -347,3 +347,11 @@ jobs:
     #   run: git diff
     # - name: Check clean up
     #   run: git diff --quiet --exit-code
+    - name: Comment PR
+      if: steps.set-vars.outputs.target == 'dev'
+      uses: thollander/actions-comment-pull-request@v2
+      with:
+        message: |
+          Make sure to review the projects you changed on the dev site: https://holoviz-dev.github.io/examples/.
+          You can also download an archive of the site from the workflow summary page, which comes in handy
+          when your dev site built was overriden by another PR (we have a single dev site!).

--- a/.github/workflows/pr_flow.yml
+++ b/.github/workflows/pr_flow.yml
@@ -8,11 +8,9 @@
 name: test+build+doc
 
 on:
-  push:
-    branches-ignore:
+  pull_request:
+    branches:
       - "main"
-      - "evaluated"
-      - "tmp_evaluated_fghgf_**"
 
 jobs:
   setup:


### PR DESCRIPTION
Noticed that this rather important step is easy to forget, so trying to nudge contributors with a comment automatically added to their PR when the dev site is deployed.
