### PR TITLE
infra: add a pre-commit hook to maintain a top-level list of deployments

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,10 @@
+repos:
+    - repo: local
+      hooks:
+        - id: update_deployments_list
+          name: Update deployments list
+          entry: python update_deployments_list.py
+          language: python
+          additional_dependencies: [pyyaml]
+          always_run: true
+          pass_filenames: false

--- a/deployments.yaml
+++ b/deployments.yaml
@@ -1,0 +1,4 @@
+- https://boids-notebook.pyviz.demo.anaconda.com
+- https://census-notebook.pyviz.demo.anaconda.com
+- https://template-notebook.pyviz.demo.anaconda.com
+- https://template.pyviz.demo.anaconda.com

--- a/update_deployments_list.py
+++ b/update_deployments_list.py
@@ -1,0 +1,36 @@
+from dodo import (
+    all_project_names,
+    deployment_cmd_to_endpoint,
+    project_spec,
+)
+
+
+def deployments_list():
+
+    projects_local = all_project_names(root='')
+
+    deployments_local = {}
+    for project in projects_local:
+        spec = project_spec(project)
+        depls = spec['examples_config'].get('deployments', [])
+        if depls:
+            deployments_local[project] = depls
+
+    return [
+        deployment_cmd_to_endpoint(depl['command'], name, full=True)
+        for name, depls in deployments_local.items()
+        for depl in depls
+    ]
+
+def main():
+
+    endpoints_local = deployments_list()
+
+    with open('deployments.yaml', 'w') as f:
+        for endpoint in endpoints_local:
+            f.write(f'- {endpoint}\n')
+        
+    return 0
+
+if __name__ == '__main__':
+    raise SystemExit(main())


### PR DESCRIPTION
@jlstevens what do you think about that? It's a simple pre-commit hook that will keep updated a top-level YAML file with a list of all the deployments declared across the project files, to be consumed by some monitoring process.

I would not merge that until we think monitoring through anyway but I wanted to have a quick feedback on this from you :) Marking as draft.