### PR TITLE
infra: fix git push in the docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -62,6 +62,12 @@ on:
   schedule:
     - cron: '0 2 * * SUN'
 
+permissions:
+  # To allow the workflow to push to the origin, when actions/checkout is used.
+  contents: write
+  # To allow the workflow to submit a comment using thollander/actions-comment-pull-request
+  pull-requests: write
+
 jobs:
   build_docs:
     # On merged PRs, workflow_call (pull_request event) or other events that can trigger this workflow (see above)

--- a/.github/workflows/pr_flow.yml
+++ b/.github/workflows/pr_flow.yml
@@ -17,9 +17,11 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
-# To allow pushing to Github when actions/checkout is used.
+# This permissions will propagate to the workflows called by this workflow.
 permissions:
+  # To allow the build workflow to push to the origin, when actions/checkout is used.
   contents: write
+  # To allow the docs workflow to submit a comment using thollander/actions-comment-pull-request
   pull-requests: write
 
 jobs:


### PR DESCRIPTION
I previously set up permissions in the pr_flow workflow which propagate to the workflow it calls. When a PR is merged, the docs workflow runs on its own, it needs additional permissions to push to the repo. Note that setting one permission disables all the other ones (see https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs), so I had to explicitly allow writing to pull-requests too. Let's see!