### PR TITLE
infra: fix build_one push

### DIFF
--- a/.github/workflows/build_one.yml
+++ b/.github/workflows/build_one.yml
@@ -120,7 +120,10 @@ jobs:
         rmdir ./tmp
         git add ./doc/gallery/$DIR
         git commit -m "adding $DIR"
-        git push --force origin $BRANCHNAME
+        echo "git status"
+        git status
+        echo "git push"
+        git push -u origin HEAD:$BRANCHNAME
         git checkout local_branch_qpeori
     - name: clean up
       run: doit clean --clean-dep build:${{ inputs.project }}


### PR DESCRIPTION
I found out there was an issue in the `build_one` workflow when pushing to the temporary evaluated branch (discovered while reviewing https://github.com/holoviz-topics/examples/pull/357). This is a recent regression introduced while removing the dependency on the `pyviz-developers` account (hopefully that was the only regression).