### PR TITLE
Make it easier to build the doc locally for one project

### DIFF
--- a/_extensions/gallery.py
+++ b/_extensions/gallery.py
@@ -151,7 +151,7 @@ def generate_gallery(app):
             files = [f for f in files if os.path.basename(f) not in skip]
         
         if not files:
-            raise ValueError(f'No files found in section {section_path}')
+            raise ValueError(f'No files found in section {section_path!r}')
         
         if len(files) > 1:
             if not any(os.path.basename(file) == 'index.ipynb' for file in files):


### PR DESCRIPTION
Adding a command to simplify building the dev site locally for a single project:

1. Run the project notebook(s), don't clean their output
2. `doit doc_one --name <project>` (for instance, `doit doc_one --name boids`): this command copies the notebooks in `./doc/gallery/<project>` along with other files needed to build the docs (thumbnails, archive, assets, etc.), and build the docs with Sphinx
3. visit the built site opening `./builtdocs/index.html`, I run `open ./builtdocs/index.html` on my machine
4. clean up with `doit clean doc_one`