### PR TITLE
Validate that notebook<7 is used

### DIFF
--- a/.github/workflows/test_one.yml
+++ b/.github/workflows/test_one.yml
@@ -78,6 +78,8 @@ jobs:
       run: doit validate_project_file:${{ inputs.project }}
     - name: validate anaconda-project lock file
       run: doit validate_project_lock:${{ inputs.project }}
+    - name: validate notebook v7 pinned
+      run: doit validate_notebook_v7_pinned:${{ inputs.project }}
     - name: validate intake catalog
       run: doit validate_intake_catalog:${{ inputs.project }}
     - name: validate data sources

--- a/dodo.py
+++ b/dodo.py
@@ -1275,11 +1275,12 @@ def task_validate_notebook_v7_pinned():
         if not deployments:
             return
         
-        depl = None
+        nb_depl = False
         for depl in deployments:
             if depl['command'] == 'notebook':
+                nb_depl = True
                 break
-        if not depl:
+        if not nb_depl:
             return
         
         lock_path = pathlib.Path(name, 'anaconda-project-lock.yml')


### PR DESCRIPTION
The Workbench platform doesn't yet support deploying read-only notebooks from environments that use `notebook` v7 or greater. This PR adds a validation step that ensures that a project that declares such a deployment locks to a previous version of `notebook`.