### PR TITLE
Ignore some anaconda-project keys when checking for project changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,9 +42,6 @@ doc/gallery/*
 jupyter_execute/
 builtdocs/
 
-# Ignore output of the git diff 
-.diff
-
 # Ignore output of test_small_data_setup
 */tmp_catalog.yml
 


### PR DESCRIPTION
There's no need to test/build a project when only some website-related metadata (e.g. maintainers list) is updated.