### PR TITLE
Restrict paths used to compute last_updated

### DIFF
--- a/dodo.py
+++ b/dodo.py
@@ -74,6 +74,17 @@ CAT_TO_CATNAME_MAP = {
     for category in categories
 }
 
+LAST_UPDATED_PATTERNS = [
+    # Notably excluded:
+    # - anaconda-project.yml (has website/deployment metadata)
+    # - /thumbnails
+    '*.ipynb',
+    '*.py',
+    'anaconda-project-lock.yml',
+    'catalog.yml',
+    'assets',
+    'data',
+]
 
 README_TEMPLATE = 'readme_template.md'
 
@@ -287,8 +298,16 @@ def last_commit_date(name, root='.', verbose=True):
     """
     Return the last committer data as 'YYYY-MM-DD'
     """
+    paths = []
+    for patt in LAST_UPDATED_PATTERNS:
+        if '*' in patt:
+            spaths = list(pathlib.Path(root, name).glob(patt))
+        else:
+            spaths = [pathlib.Path(root, name, patt)]
+        paths.extend(spaths)
+    paths = ' '.join([str(p) for p in paths if p.exists()])
     proc = subprocess.run(
-        [f'git log -n 1 --pretty=format:%cs {root}/{name}'],
+        [f'git log -n 1 --pretty=format:%cs {paths}'],
         check=True, capture_output=True, text=True, shell=True,
     )
     last_committer_date = proc.stdout


### PR DESCRIPTION
I recently touched all the `anaconda-project.yml` files (adding `categories` in there). `Last Updated` was computed based on any change made in a project folder, so all the projects got the same data of my PR. Not good! With this change, there's now an explicit list of files/folders watched, excluding by default `anaconda-project.yml`.