### PR TITLE
Fix multichannel timeseries deployments

### DIFF
--- a/multichannel_timeseries/anaconda-project.yml
+++ b/multichannel_timeseries/anaconda-project.yml
@@ -31,7 +31,7 @@ channels:
 - nodefaults
 
 packages: &pkgs
-- notebook>=6.5.2,<7 # required
+- notebook>=6,<7 # required
 - python=3.11
 - numpy>=2.0.2 # auto min pinned 2024-11-18
 - panel>=1.4.2
@@ -62,8 +62,8 @@ commands:
   lab:
     unix: jupyter lab index.ipynb
     windows: jupyter lab index.ipynb
-  notebook:
-    notebook: index.ipynb
+  # notebook:
+  #   notebook: index.ipynb
   dashboard:
     unix: panel serve --rest-session-info --session-history -1 0_multichan.ipynb --show
     supports_http_options: true

--- a/multichannel_timeseries/anaconda-project.yml
+++ b/multichannel_timeseries/anaconda-project.yml
@@ -31,7 +31,7 @@ channels:
 - nodefaults
 
 packages: &pkgs
-- notebook>=6,<7 # required
+- notebook>=6.5.2,<7 # required
 - python=3.11
 - numpy>=2.0.2 # auto min pinned 2024-11-18
 - panel>=1.4.2

--- a/multichannel_timeseries/anaconda-project.yml
+++ b/multichannel_timeseries/anaconda-project.yml
@@ -65,7 +65,7 @@ commands:
   notebook:
     notebook: index.ipynb
   dashboard:
-    unix: panel serve --rest-session-info --session-history -1 multichan.ipynb --show
+    unix: panel serve --rest-session-info --session-history -1 0_multichan.ipynb --show
     supports_http_options: true
 
 variables: {}


### PR DESCRIPTION
- Fix path to deployed (with Panel) notebook
- Disable notebook deployment for now because of an error on AE5

```
2024-11-20T14:49:34.682109447Z An unexpected error occurred, most likely a bug in anaconda-project.
2024-11-20T14:49:34.682148528Z     (The error was: AssertionError: )
2024-11-20T14:49:34.682496073Z Bug details for anaconda-project error on 2024-11-20
2024-11-20T14:49:34.682503193Z 
2024-11-20T14:49:34.682507223Z sys.argv: ['/opt/continuum/anaconda/bin/anaconda-project', '--verbose', 'prepare', '--command', 'notebook']
2024-11-20T14:49:34.682509763Z 
2024-11-20T14:49:34.682559625Z {'version': '0.11.1'}
2024-11-20T14:49:34.682565605Z 
2024-11-20T14:49:34.685521620Z Traceback (most recent call last):
2024-11-20T14:49:34.685540170Z 
2024-11-20T14:49:34.685543411Z   File "/opt/continuum/anaconda/lib/python3.12/site-packages/anaconda_project/internal/cli/bug_handler.py", line 31, in handle_bugs
2024-11-20T14:49:34.685546381Z     return main_func()
2024-11-20T14:49:34.685548761Z            ^^^^^^^^^^^
2024-11-20T14:49:34.685550791Z 
2024-11-20T14:49:34.685553011Z   File "/opt/continuum/anaconda/lib/python3.12/site-packages/anaconda_project/internal/cli/main.py", line 435, in _main_without_bug_handler
2024-11-20T14:49:34.685558251Z     return _parse_args_and_run_subcommand(sys.argv)
2024-11-20T14:49:34.685560561Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-20T14:49:34.685562431Z 
2024-11-20T14:49:34.685565121Z   File "/opt/continuum/anaconda/lib/python3.12/site-packages/anaconda_project/internal/cli/main.py", line 427, in _parse_args_and_run_subcommand
2024-11-20T14:49:34.685567791Z     return args.main(args)
2024-11-20T14:49:34.685569881Z            ^^^^^^^^^^^^^^^
2024-11-20T14:49:34.685572111Z 
2024-11-20T14:49:34.685574962Z   File "/opt/continuum/anaconda/lib/python3.12/site-packages/anaconda_project/internal/cli/prepare.py", line 40, in main
2024-11-20T14:49:34.685577832Z     if prepare_command(args.directory, args.mode, args.env_spec, args.command, args.all, args.refresh):
2024-11-20T14:49:34.685597442Z        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-20T14:49:34.685599522Z 
2024-11-20T14:49:34.685601712Z   File "/opt/continuum/anaconda/lib/python3.12/site-packages/anaconda_project/internal/cli/prepare.py", line 32, in prepare_command
2024-11-20T14:49:34.685603902Z     if not prepare_with_ui_mode_printing_errors(
2024-11-20T14:49:34.685606082Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-20T14:49:34.685608002Z 
2024-11-20T14:49:34.685610512Z   File "/opt/continuum/anaconda/lib/python3.12/site-packages/anaconda_project/internal/cli/prepare_with_mode.py", line 138, in prepare_with_ui_mode_printing_errors
2024-11-20T14:49:34.685613062Z     result = prepare.prepare_without_interaction(project,
2024-11-20T14:49:34.685615192Z              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-20T14:49:34.685617062Z 
2024-11-20T14:49:34.685619142Z   File "/opt/continuum/anaconda/lib/python3.12/site-packages/anaconda_project/prepare.py", line 952, in prepare_without_interaction
2024-11-20T14:49:34.685621252Z     return prepare_execute_without_interaction(stage)
2024-11-20T14:49:34.685623362Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-20T14:49:34.685625253Z 
2024-11-20T14:49:34.685627343Z   File "/opt/continuum/anaconda/lib/python3.12/site-packages/anaconda_project/prepare.py", line 963, in prepare_execute_without_interaction
2024-11-20T14:49:34.685629803Z     next_stage = stage.execute()
2024-11-20T14:49:34.685632333Z                  ^^^^^^^^^^^^^^^
2024-11-20T14:49:34.685634593Z 
2024-11-20T14:49:34.685637173Z   File "/opt/continuum/anaconda/lib/python3.12/site-packages/anaconda_project/prepare.py", line 363, in execute
2024-11-20T14:49:34.685639353Z     next = self._stage.execute()
2024-11-20T14:49:34.685641463Z            ^^^^^^^^^^^^^^^^^^^^^
2024-11-20T14:49:34.685643373Z 
2024-11-20T14:49:34.685645473Z   File "/opt/continuum/anaconda/lib/python3.12/site-packages/anaconda_project/prepare.py", line 307, in execute
2024-11-20T14:49:34.685647663Z     return self._execute(self)
2024-11-20T14:49:34.685649913Z            ^^^^^^^^^^^^^^^^^^^
2024-11-20T14:49:34.685651793Z 
2024-11-20T14:49:34.685654033Z   File "/opt/continuum/anaconda/lib/python3.12/site-packages/anaconda_project/prepare.py", line 472, in provide_stage
2024-11-20T14:49:34.685656703Z     result = status.provider.provide(status.requirement, context)
2024-11-20T14:49:34.685658803Z              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2024-11-20T14:49:34.685660683Z 
2024-11-20T14:49:34.685663303Z   File "/opt/continuum/anaconda/lib/python3.12/site-packages/anaconda_project/requirements_registry/providers/conda_env.py", line 225, in provide
2024-11-20T14:49:34.685665613Z     conda.fix_environment_deviations(prefix, env_spec, create=(not inherited))
2024-11-20T14:49:34.685667463Z 
2024-11-20T14:49:34.685669483Z   File "/opt/continuum/anaconda/lib/python3.12/site-packages/anaconda_project/internal/default_conda_manager.py", line 455, in fix_environment_deviations
2024-11-20T14:49:34.685671603Z     assert len(specs) == len(missing)
2024-11-20T14:49:34.685673523Z 
2024-11-20T14:49:34.685675693Z AssertionError
2024-11-20T14:49:34.685677543Z 
2024-11-20T14:49:34.685734504Z Above details were also saved to /tmp/bug_details_anaconda-project_2024-11-20_qt494zwe.txt
2024-11-20T14:49:34.769542716Z Command exited with non-zero status 1

```