### PR TITLE
Add standalone app to volumetric imaging example

### DIFF
--- a/volumetric_imaging/volumetric_imaging.ipynb
+++ b/volumetric_imaging/volumetric_imaging.ipynb
@@ -27,6 +27,9 @@
    "execution_count": null,
    "id": "ef81c950-38e8-4c18-aec0-63ce70c34b1f",
    "metadata": {
+    "jupyter": {
+     "source_hidden": true
+    },
     "panel-layout": {
      "height": 345,
      "visible": true,
@@ -166,7 +169,7 @@
     "\n",
     "You can either:\n",
     "\n",
-    "- Pass a valid [Neuroglancer URL]([Neuroglancer repository](https://github.com/google/neuroglancer#examples) to `Neuroglancer(source=<URL>)`.\n",
+    "- Pass a valid [Neuroglancer URL](https://github.com/google/neuroglancer#examples) to `Neuroglancer(source=<URL>)`.\n",
     "- Launch a blank viewer using `Neuroglancer()`, paste the URL into the text input, and hit `Load`.\n",
     "\n",
     "Optionally, Panel-Neuroglancer includes a predefined `demo` URL loader button (or `load_demo=True` when instantiating) to quickly load an example dataset and state. You can find example URLs in the [Neuroglancer repository](https://github.com/google/neuroglancer#examples)."
@@ -497,6 +500,36 @@
   },
   {
    "cell_type": "markdown",
+   "id": "930576dd-8485-4de8-b2dc-9ca3df12748e",
+   "metadata": {},
+   "source": [
+    "### Standalone App Extension\n",
+    "\n",
+    "HoloViz Panel allows for the deployment of this complex visualization as a standalone, template-styled, interactive web application (outside of a Jupyter Notebook). Read more about Panel [here](https://panel.holoviz.org/).\n",
+    "\n",
+    "We'll add our plots to the `main` area of a Panel Template component and set the entire component to be `servable`.\n",
+    "\n",
+    "To launch the standalone app, activate the same conda environment and run `panel serve <path-to-this-file> --show` in the command line to open the application in a browser window (tip: use the `--dev` flag to auto update the app when the file changes)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b8a0ae50-28a6-48e8-adb4-7d7831a94cab",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "servable_app = pn.template.FastListTemplate(\n",
+    "    title = \"Panel Neuroglancer for Volumetric Imaging\",\n",
+    "    main = Neuroglancer(show_state=True, load_demo=True),\n",
+    "    main_layout=None,\n",
+    "    theme=\"dark\",\n",
+    "    accent=\"#bb5457\"\n",
+    ").servable()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
    "id": "1247343e-44b5-46a8-a05d-511d1a392e9d",
    "metadata": {
     "panel-layout": {
@@ -547,7 +580,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.10"
+   "version": "3.11.11"
   },
   "panel-cell-order": [
    "cc47db48-cd14-4874-a377-e4c13de91cdd",


### PR DESCRIPTION
This is a reversal of my previous position that a standalone app should not be included for the volumetric imaging example. Due to complications on the technical deployment side of things with a notebook that doesn't have a `.servable`, and because of the argument that part of the notebook includes using the `panel neuroglancer` view as a component in a larger dashboard, I've come around to thinking that it's fine to now include a standalone app example. 

